### PR TITLE
Process multiple tracks within a single HTML paragraph tag

### DIFF
--- a/src/bbc_meet_spotify/bbc_sounds.py
+++ b/src/bbc_meet_spotify/bbc_sounds.py
@@ -135,11 +135,11 @@ class PlaylistScraper(ScraperBase):
         song_tag = "p"
         # can be separated by dashes or hyphens
         for separator in [" – ", " - "]:
-            track_strings.extend([
-                (i.text.strip().split(separator))
-                for i in header.find_all_previous(song_tag)
-                if separator in i.text
-            ])
+            for track_tag in header.find_all_previous(song_tag):
+                for track_contents in track_tag.contents:
+                    track_contents_string = track_contents.text
+                    if separator in track_contents_string:
+                        track_strings.extend([track_contents_string.strip().split(separator)])
 
         songs = [(artist, song_name) for artist, song_name in track_strings]
         return songs

--- a/tests/resources/bbc_sounds_6music.html
+++ b/tests/resources/bbc_sounds_6music.html
@@ -145,6 +145,7 @@
                         <p><strong>Little Simz - might bang, might not</strong></p>
                         <p>Sorry - Perfect</p>
                         <p>Willie J Healey - True Stereo</p>
+                        <p>Jack White - Fear Of The Dawn<br><br>Johnny Marr - Night and Day</p>
                       </div>
                     </div>
                   </div>

--- a/tests/test_bbc_sounds.py
+++ b/tests/test_bbc_sounds.py
@@ -16,7 +16,7 @@ class TestPlaylistParsing:
         bbc_sounds = BBCSounds("six_music", True, "testing me", self.playlist_config)
 
         output_songs = bbc_sounds.get_songs()
-        assert len(output_songs) == 33
+        assert len(output_songs) == 35
 
         # test first song (reverse order)
         assert output_songs[0].artist == "Tim Burgess"


### PR DESCRIPTION
[Radio6's Playlist Page](https://www.bbc.co.uk/programmes/articles/5JDPyPdDGs3yCLdtPhGgWM7/bbc-radio-6-music-playlist) can return multiple track listing in the one HTML Paragraph. This was causing `ValueError: too many values to unpack (expected 2)` when unpacking, since `track_strings` contained more than 2 elements:
`(artist, song_name) for artist, song_name in track_strings`

With this approach, we will parse all tags from the contents, thus processing all tracks and not crashing the app.

![Screenshot 2022-02-28 at 18 29 21](https://user-images.githubusercontent.com/11885462/156038137-057e0bdc-230b-4c01-b34b-7c60b207f457.png)

I've successfully run the app the past 2 weeks and have confirmed it works as expected whereas current code crashes.