### PR TITLE
Only write playlist history upon successful run

### DIFF
--- a/src/bbc_meet_spotify/console.py
+++ b/src/bbc_meet_spotify/console.py
@@ -32,12 +32,15 @@ def console(
 
     music = bbc_sounds.get_music()
     spotify = Spotify()
-    if bbc_sounds.type == "album":
-        spotify.add_albums(bbc_sounds.playlist_suffix, music, date_prefix, public_playlist)
-    else:
-        spotify.add_songs(bbc_sounds.playlist_suffix, music, date_prefix, public_playlist)
+    if music:
+        if bbc_sounds.type == "album":
+            spotify.add_albums(bbc_sounds.playlist_suffix, music, date_prefix, public_playlist)
+        else:
+            spotify.add_songs(bbc_sounds.playlist_suffix, music, date_prefix, public_playlist)
 
-    bbc_sounds.write_playlist_history(music)
+        bbc_sounds.write_playlist_history(music)
+    else:
+        logger.info("No new music to add to the playlist")
 
 
 def main():

--- a/src/bbc_meet_spotify/console.py
+++ b/src/bbc_meet_spotify/console.py
@@ -37,6 +37,8 @@ def console(
     else:
         spotify.add_songs(bbc_sounds.playlist_suffix, music, date_prefix, public_playlist)
 
+    bbc_sounds.write_playlist_history(music)
+
 
 def main():
     typer.run(console)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,44 @@
+from bbc_meet_spotify.console import console
+from bbc_meet_spotify.music import Music
+from bbc_meet_spotify.playlist_parsing import PlaylistChoices
+from unittest.mock import patch, MagicMock, ANY
+
+
+def test_invalid_playlist_type():
+    try:
+        console(PlaylistChoices("invalid"))
+    except ValueError:
+        pass
+
+
+@patch("bbc_meet_spotify.console.BBCSounds")
+@patch("bbc_meet_spotify.console.Spotify")
+def test_add_songs(mock_spotify: MagicMock, mock_bbc_sounds: MagicMock):
+    mock_bbc_sounds_instance = mock_bbc_sounds.return_value
+    mock_spotify_instance = mock_spotify.return_value
+    music = {Music("artist", "title")}
+    mock_bbc_sounds_instance.get_music.return_value = music
+    playlist_name = "suffix"
+    mock_bbc_sounds_instance.playlist_suffix = playlist_name
+    console(PlaylistChoices("six_music"))
+    mock_bbc_sounds_instance.get_music.assert_called_once()
+    mock_spotify_instance.add_albums.assert_not_called()
+    mock_spotify_instance.add_songs.assert_called_with(playlist_name, music, ANY, ANY)
+    mock_bbc_sounds_instance.write_playlist_history.assert_called_with(music)
+
+
+@patch("bbc_meet_spotify.console.BBCSounds")
+@patch("bbc_meet_spotify.console.Spotify")
+def test_add_albums(mock_spotify: MagicMock, mock_bbc_sounds: MagicMock):
+    mock_bbc_sounds_instance = mock_bbc_sounds.return_value
+    mock_spotify_instance = mock_spotify.return_value
+    music = {Music("artist", "title")}
+    mock_bbc_sounds_instance.get_music.return_value = music
+    mock_bbc_sounds_instance.type = "album"
+    playlist_name = "suffix"
+    mock_bbc_sounds_instance.playlist_suffix = playlist_name
+    console(PlaylistChoices("six_music"))
+    mock_bbc_sounds_instance.get_music.assert_called_once()
+    mock_spotify_instance.add_albums.assert_called_with(playlist_name, music, ANY, ANY)
+    mock_spotify_instance.add_songs.assert_not_called()
+    mock_bbc_sounds_instance.write_playlist_history.assert_called_with(music)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -42,3 +42,19 @@ def test_add_albums(mock_spotify: MagicMock, mock_bbc_sounds: MagicMock):
     mock_spotify_instance.add_albums.assert_called_with(playlist_name, music, ANY, ANY)
     mock_spotify_instance.add_songs.assert_not_called()
     mock_bbc_sounds_instance.write_playlist_history.assert_called_with(music)
+
+
+@patch("bbc_meet_spotify.console.BBCSounds")
+@patch("bbc_meet_spotify.console.Spotify")
+def test_exits_when_no_new_music(mock_spotify: MagicMock, mock_bbc_sounds: MagicMock):
+    mock_bbc_sounds_instance = mock_bbc_sounds.return_value
+    mock_spotify_instance = mock_spotify.return_value
+    music = []
+    mock_bbc_sounds_instance.get_music.return_value = music
+    playlist_name = "suffix"
+    mock_bbc_sounds_instance.playlist_suffix = playlist_name
+    console(PlaylistChoices("six_music"))
+    mock_bbc_sounds_instance.get_music.assert_called_once()
+    mock_spotify_instance.add_albums.assert_not_called()
+    mock_spotify_instance.add_songs.assert_not_called()
+    mock_bbc_sounds_instance.write_playlist_history.assert_not_called()


### PR DESCRIPTION
**Context**
There seems to be a flaw in the logic with the current implementation, whereby it's possible to observe the following scenario:

- The application extracts the current music from the BBC Sounds Music website
- The application preserves the history in the `playlist_history/*.toml` file
- The application calls the Spotify API, which can fail and therefore not update the Playlist
- A re-run will never process the music again, since it's preserved in the `playlist_history/*.toml` file

**Proposed solution**

- Move the saving of the playlist history to the end, so that it's only updated after a successful run.

Thanks in advance for taking a look. Please feel free to suggest an alternative approach or clarify if I've misunderstood something. 